### PR TITLE
samples/qemuarm64.yml: Update meta-thistle and add TUC

### DIFF
--- a/samples/qemuarm64.yml
+++ b/samples/qemuarm64.yml
@@ -6,7 +6,8 @@ machine: qemuarm64-thistle
 distro: thistle-base
 
 thistle-features:
-  meta-thistle: e05a0ab0e3abfc3c8fcb5371fdffa451765826af
+  meta-thistle: b90acb0a89eab8e123416e437f1f5f2186788f07
+  updater: true
   curl:
     bin: true
     lib: true

--- a/samples/qemuarm64.yml
+++ b/samples/qemuarm64.yml
@@ -6,7 +6,8 @@ machine: qemuarm64-thistle
 distro: thistle-base
 
 thistle-features:
-  meta-thistle: b90acb0a89eab8e123416e437f1f5f2186788f07
+  # 20240228
+  meta-thistle: e9829382a1379e60e41da482793009de536de45a
   updater: true
   curl:
     bin: true

--- a/samples/raspberrypi4.yml
+++ b/samples/raspberrypi4.yml
@@ -6,7 +6,8 @@ machine: raspberrypi4-64-thistle
 distro: thistle-base
 
 thistle-features:
-  meta-thistle: e05a0ab0e3abfc3c8fcb5371fdffa451765826af
+  # 20240228
+  meta-thistle: e9829382a1379e60e41da482793009de536de45a
   updater: true
   curl:
     bin: true


### PR DESCRIPTION
We update `meta-thistle` to add TUC 0.2.0 in the QEMU ARM64 image.