### PR TITLE
Roll openembedded-core refspec

### DIFF
--- a/samples/portenta-x8.yml
+++ b/samples/portenta-x8.yml
@@ -47,7 +47,8 @@ repos:
 
   openembedded-core:
     url: git://git.openembedded.org/openembedded-core
-    refspec: 54ee67b1a805a07288925d56e9956aabc23b6ab2
+    # 2024-10-12
+    refspec: f09fca692f96c9c428e89c5ef53fbcb92ac0c9bf
     layers:
       - meta
 

--- a/samples/qemuarm64.yml
+++ b/samples/qemuarm64.yml
@@ -17,7 +17,8 @@ thistle-features:
 repos:
   openembedded-core:
     url: git://git.openembedded.org/openembedded-core
-    refspec: 54ee67b1a805a07288925d56e9956aabc23b6ab2
+    # 2024-10-12
+    refspec: f09fca692f96c9c428e89c5ef53fbcb92ac0c9bf
     layers:
       - meta
 

--- a/samples/raspberrypi4.yml
+++ b/samples/raspberrypi4.yml
@@ -17,7 +17,8 @@ thistle-features:
 repos:
   openembedded-core:
     url: git://git.openembedded.org/openembedded-core
-    refspec: 54ee67b1a805a07288925d56e9956aabc23b6ab2
+    # 2024-10-12
+    refspec: f09fca692f96c9c428e89c5ef53fbcb92ac0c9bf
     layers:
       - meta
 


### PR DESCRIPTION
Update the commit SHA for `openembedded-core` as an attempt to resolve a recent build breakage due to dependency issues.