### PR TITLE
Add Dockerfiles for rpi4 and qemu images

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,34 @@ _note_: the project only builds on x86_64 linux due to C dependency on [crypt(3)
 $ make release
 ```
 
-### Docker Usage
+### Build Images with Docker
 
-Build image
+#### Build QEMU image for ARM64
+
 ```sh
-$ docker build -t tyb .
+$ docker build --platform=linux/amd64 \
+    -f dockerfiles/Dockerfile.qemuarm64 \
+    -t qemuarm64:latest \
+    .
+
+$ mkdir build_out && chmod 777 build_out
+# Copy built images to build_out/
+$ docker run -v "$(pwd)/build_out":/home/builder/tyb_build_out \
+    --rm -i qemuarm64:latest \
+    /bin/bash -c "cp -r /home/builder/build/deploy/images/* /home/builder/tyb_build_out/"
 ```
 
-Run build on docker image
+#### Build Raspberry Pi 4 image with [OPTIGA™ Trust-M Linux tools](https://github.com/Infineon/linux-optiga-trust-m)
+
 ```sh
-$ mkdir build
-$ cp samples/qemuarm64.yml build/
-$ docker run --rm -v $(pwd)/build:/home/builder tyb thistle-yocto-build qemuarm64.yml build debug
+$ docker build --platform=linux/amd64 \
+    -f dockerfiles/Dockerfile.rpi4-trustm \
+    -t rpi4trustm:latest \
+    .
+
+$ mkdir build_out && chmod 777 build_out
+# Copy built images to build_out/
+$ docker run -v "$(pwd)/build_out":/home/builder/tyb_build_out \
+    --rm -i rpi4trustm:latest \
+    /bin/bash -c "cp -r /home/builder/build/deploy/images/* /home/builder/tyb_build_out/"
 ```

--- a/dockerfiles/Dockerfile.qemuarm64
+++ b/dockerfiles/Dockerfile.qemuarm64
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04
+ARG TYB_VERSION="v2.3.0"
+RUN apt update && apt upgrade -y && \
+  DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+  gawk wget git-core diffstat unzip texinfo gcc-multilib \
+  build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
+  xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \
+  libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd lz4 file \
+  curl locales vim dpkg
+
+# RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+#    locale-gen
+RUN locale-gen en_US && locale-gen en_US.UTF-8 && update-locale
+
+# Create user "builder"
+RUN useradd -m builder && \
+    cp /root/.bashrc /home/builder/ && \
+    chown -R --from=root builder /home/builder
+USER builder
+WORKDIR /home/builder
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV THISTLE_YOCTO_BUILD_USERNAME thistle
+ENV THISTLE_YOCTO_BUILD_PASSWORD is_awesome
+RUN echo PIG_${TYB_VERSION}
+RUN curl -L -o thistle-yocto-build https://github.com/thistletech/thistle-yocto-build/releases/download/${TYB_VERSION}/thistle-yocto-build && \
+  chmod +x thistle-yocto-build
+RUN locale > read.txt
+RUN ./thistle-yocto-build gen-config qemu
+RUN ./thistle-yocto-build build --debug conf.yml

--- a/dockerfiles/Dockerfile.rpi4-trustm
+++ b/dockerfiles/Dockerfile.rpi4-trustm
@@ -1,0 +1,33 @@
+FROM ubuntu:22.04
+ARG TYB_VERSION="v2.3.0"
+RUN apt update && apt upgrade -y && \
+  DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+  gawk wget git-core diffstat unzip texinfo gcc-multilib \
+  build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
+  xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \
+  libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd lz4 file \
+  curl locales vim dpkg
+
+# RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+#    locale-gen
+RUN locale-gen en_US && locale-gen en_US.UTF-8 && update-locale
+
+# Create user "builder"
+RUN useradd -m builder && \
+    cp /root/.bashrc /home/builder/ && \
+    chown -R --from=root builder /home/builder
+USER builder
+WORKDIR /home/builder
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV THISTLE_YOCTO_BUILD_USERNAME thistle
+ENV THISTLE_YOCTO_BUILD_PASSWORD is_awesome
+RUN curl -L -o thistle-yocto-build https://github.com/thistletech/thistle-yocto-build/releases/download/${TYB_VERSION}/thistle-yocto-build && \
+  chmod +x thistle-yocto-build
+RUN locale > read.txt
+RUN ./thistle-yocto-build gen-config rpi4
+RUN echo '    IMAGE_INSTALL:append = " trust-m trust-m-dev"' >> conf.yml && \
+  echo '    KERNEL_MODULE_AUTOLOAD:rpi += "i2c-dev i2c-bcm2708"' >> conf.yml && \
+  echo '    ENABLE_I2C = "1"' >> conf.yml
+RUN ./thistle-yocto-build build --debug conf.yml


### PR DESCRIPTION
Add dockerfiles/ directory, providing Dockerfiles for RPi-4 and QEMU ARM64 builds. 

Update README.md with docker build instructions.