### PR TITLE
Update TUC to v1.4.0 for RPi-4 and QEMU configs

### DIFF
--- a/samples/qemuarm64.yml
+++ b/samples/qemuarm64.yml
@@ -6,8 +6,8 @@ machine: qemuarm64-thistle
 distro: thistle-base
 
 thistle-features:
-  # 20240228
-  meta-thistle: e9829382a1379e60e41da482793009de536de45a
+  # 20250306 (tuc v1.4.0)
+  meta-thistle: 85658ee88da7f3fbf9549c8ad2936268bfe27726
   updater: true
   curl:
     bin: true

--- a/samples/raspberrypi4.yml
+++ b/samples/raspberrypi4.yml
@@ -6,8 +6,8 @@ machine: raspberrypi4-64-thistle
 distro: thistle-base
 
 thistle-features:
-  # 20240228
-  meta-thistle: e9829382a1379e60e41da482793009de536de45a
+  # 20250306 (tuc v1.4.0)
+  meta-thistle: 85658ee88da7f3fbf9549c8ad2936268bfe27726
   updater: true
   curl:
     bin: true


### PR DESCRIPTION
Update TUC from v0.2.0 to v1.4.0.